### PR TITLE
chore: make dependencies dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+- Externalize Vue ([#247](https://github.com/demos-europe/demosplan-js-addon/pull/247))
+
+
 ## v0.0.10 - 21-03-2025
 
 - Bump vue-loader to v16.8.3; add compatConfig to vue-loader  ([#246](https://github.com/demos-europe/demosplan-js-addon/pull/246))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Use DevDepenencies instead of dependencies ([#247](https://github.com/demos-europe/demosplan-js-addon/pull/247))
+- Use DevDependencies instead of dependencies ([#247](https://github.com/demos-europe/demosplan-js-addon/pull/247))
 
 
 ## v0.0.10 - 21-03-2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Externalize Vue ([#247](https://github.com/demos-europe/demosplan-js-addon/pull/247))
+- Use DevDepenencies instead of dependencies ([#247](https://github.com/demos-europe/demosplan-js-addon/pull/247))
 
 
 ## v0.0.10 - 21-03-2025

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Base dependency for frontend configuration in demosplan-core addons.",
   "license": "MIT",
   "main": "./src/index.js",
-  "dependencies": {
+  "devDependencies": {
     "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.2",
     "autoprefixer": "^10.4.13",

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,9 @@ function configBuilder(addon_name, entrypoints) {
     resolve: {
       extensions: ['.js', '.vue']
     },
+    externals: {
+      vue: 'Vue',
+    },
     devtool: isProduction ? 'nosources-source-map': 'eval-source-map',
     plugins: [
       new MiniCssExtractPlugin(),

--- a/src/index.js
+++ b/src/index.js
@@ -67,9 +67,6 @@ function configBuilder(addon_name, entrypoints) {
     resolve: {
       extensions: ['.js', '.vue']
     },
-    externals: {
-      vue: 'Vue',
-    },
     devtool: isProduction ? 'nosources-source-map': 'eval-source-map',
     plugins: [
       new MiniCssExtractPlugin(),


### PR DESCRIPTION
I think it doesn't change so much, but it should be clear, that those dependencies are for build-time only

related: https://github.com/demos-europe/demosplan-core/pull/4569