### PR TITLE
Add a new rule for custom blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## UNRELEASED
 
+- Add a new rule to config builder for custom blocks ([#249](https://github.com/demos-europe/demosplan-js-addon/pull/249))
 - Use DevDependencies instead of dependencies ([#247](https://github.com/demos-europe/demosplan-js-addon/pull/247))
-
 
 ## v0.0.10 - 21-03-2025
 

--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,10 @@ function configBuilder(addon_name, entrypoints) {
     module: {
       rules: [
         {
+          resourceQuery: /blockType=license/,
+          loader: path.resolve(__dirname, './removeSFCBlockLoader.js')
+        },
+        {
           test: /\.vue$/,
           loader: 'vue-loader',
           options: {

--- a/src/removeSFCBlockLoader.js
+++ b/src/removeSFCBlockLoader.js
@@ -1,0 +1,12 @@
+/**
+ * This loader captures any <license> custom block (matched by resourceQuery: /blockType=license/).
+ * Without a loader, vue-loader would throw a syntax error when encountering <license> blocks.
+ * By returning an empty string here, we remove those blocks, allowing vue-loader to continue without interruption.
+ */
+module.exports = function (source, map) {
+  this.callback(
+    null,
+    '',
+    map
+  )
+}

--- a/src/removeSFCBlockLoader.js
+++ b/src/removeSFCBlockLoader.js
@@ -2,6 +2,7 @@
  * This loader captures any <license> custom block (matched by resourceQuery: /blockType=license/).
  * Without a loader, vue-loader would throw a syntax error when encountering <license> blocks.
  * By returning an empty string here, we remove those blocks, allowing vue-loader to continue without interruption.
+ * (https://vue-loader.vuejs.org/guide/custom-blocks.html#example)
  */
 module.exports = function (source, map) {
   this.callback(


### PR DESCRIPTION
**Description:** This PR adds a new rule into the webpack config file.

- add `removeSFCBlockLoader.js` which captures any `<license>` custom block (matched by resourceQuery: /blockType=license/). Without a loader, vue-loader would throw a syntax error when encountering `<license>` blocks. By returning an empty string here, we remove those blocks, allowing vue-loader to continue without interruption. (https://vue-loader.vuejs.org/guide/custom-blocks.html#example)